### PR TITLE
Add overloading to GetManager

### DIFF
--- a/src/Microsoft.AspNet.WebHooks.Custom/Services/CustomServices.cs
+++ b/src/Microsoft.AspNet.WebHooks.Custom/Services/CustomServices.cs
@@ -189,6 +189,29 @@ namespace Microsoft.AspNet.WebHooks.Services
         }
 
         /// <summary>
+        /// Gets a default <see cref="IWebHookManager"/> implementation which is used if none are registered with the 
+        /// Dependency Injection engine.
+        /// </summary>
+        /// <returns>A default <see cref="IWebHookManager"/> instance.</returns>
+        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Disposed by AppDomain")]
+        public static IWebHookManager GetManager(ILogger logger)
+        {
+            if (_manager != null)
+            {
+                return _manager;
+            }
+           
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            IWebHookManager instance = new WebHookManager(GetStore(), GetSender(logger), logger);
+            Interlocked.CompareExchange(ref _manager, instance, null);
+            return _manager;
+        }
+
+        /// <summary>
         /// Gets a default <see cref="IWebHookRegistrationsManager"/> implementation which is used if none are registered with the 
         /// Dependency Injection engine.
         /// </summary>


### PR DESCRIPTION
Hello, 

In my code I need to inject dependency to `IWebHookManager`. I'm using Unity to register dependency like:

```
ILogger logger = new TraceLogger();
container.RegisterInstance<IWebHookManager>(new WebHookManager(
	CustomServices.GetStore(),
	CustomServices.GetSender(logger),
	logger
));
```

What do you think about creating a new overloading of `GetManager()`? Then there will be possibility to create default `Web HookManager`:

```
container.RegisterInstance<IWebHookManager>(CustomServices.GetManager(new TraceLogger()));
```

Thank you in advance