### PR TITLE
Add CredScanSuppressions file

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "placeholder": "1vsBmi8vJKP+tm3iG+K6cSdi7v6AFdx8vqGSDQyozw4=",
+      "_justification": "This is a fake password hash used in test code."
+    }
+  ]
+}


### PR DESCRIPTION
Suppresses credScan warnings about an old fake secret checked in to a test file: https://github.com/aspnet/AspNetWebHooks/blob/8c452662ec47fd72d0e80c83703b2493c87e5c45/test/Microsoft.AspNet.WebHooks.Receivers.Instagram.Test/WebHooks/InstagramWebHookClientTests.cs#L25

Without this we can't push this repo to AzDO.