### PR TITLE
Add pipeline for AspnetWebhooks

### DIFF
--- a/.artifactignore
+++ b/.artifactignore
@@ -1,0 +1,6 @@
+syntax: glob
+
+artifacts/CodeAnalysis/**/*
+artifacts/Test/**/*
+artifacts/Release/**/*
+!artifacts/Release/**/*.nupkg

--- a/.artifactignore
+++ b/.artifactignore
@@ -1,6 +1,0 @@
-syntax: glob
-
-artifacts/CodeAnalysis/**/*
-artifacts/Test/**/*
-artifacts/Release/**/*
-!artifacts/Release/**/*.nupkg

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -69,13 +69,6 @@ jobs:
             $(BuildScriptArgs)
             /bl:artifacts/logs/Build-Release.binlog
     displayName: Build (Release)
-  - task: CopyFiles@2
-    displayName: Copy logs to artifacts/
-    inputs:
-      sourceFolder: $(Build.SourcesDirectory)/bin/
-      contents: 'logs/**'
-      targetFolder: $(Build.SourcesDirectory)/artifacts/
-  - task: CopyFiles@2
     displayName: Copy packages to artifacts/
     inputs:
       sourceFolder: $(Build.SourcesDirectory)/bin/
@@ -146,11 +139,20 @@ jobs:
         packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/**/*.symbols.nupkg'
       displayName: Publish symbols to general-testing-symbols
     - task: PublishBuildArtifacts@1
-      displayName: Upload artifacts
+      displayName: Upload packages
       condition: eq(variables['system.pullrequest.isfork'], false)
       continueOnError: true
       inputs:
-        pathtoPublish: artifacts/
-        artifactName: artifacts-AspnetWebHooks-Signed
+        pathtoPublish: artifacts/packages/
+        artifactName: artifacts-AspnetWebHooks-Signed-packages
+        artifactType: Container
+        parallel: true
+    - task: PublishBuildArtifacts@1
+      displayName: Upload logs
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: artifacts/logs/
+        artifactName: artifacts-AspnetWebHooks-Signed-logs
         artifactType: Container
         parallel: true

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -15,7 +15,6 @@ resources:
     type: github
     endpoint: aspnet
     name: aspnet/AspnetWebHooks-Signed
-    ref: wtgodbe/SignTool
 
 variables:
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -128,14 +128,14 @@ jobs:
       inputs:
         command: 'push'
         feedsToUse: 'select'
-        vstsFeed: 'public/general-testing'
+        publishVstsFeed: 'public/general-testing'
         packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/**/*.symbols.nupkg'
       displayName: Publish packages to general-testing
     - task: NuGetCommand@2
       inputs:
         command: 'push'
         feedsToUse: 'select'
-        vstsFeed: 'public/general-testing-symbols'
+        publishVstsFeed: 'public/general-testing-symbols'
         packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/**/*.symbols.nupkg'
       displayName: Publish symbols to general-testing-symbols
     - task: PublishBuildArtifacts@1

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -13,7 +13,6 @@ resources:
     type: github
     endpoint: aspnet
     name: aspnet/AspnetWebHooks-Signed
-    ref: wtgodbe/SignTool2
 
 variables:
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -15,6 +15,7 @@ resources:
     type: github
     endpoint: aspnet
     name: aspnet/AspnetWebHooks-Signed
+    ref: wtgodbe/SignTool
 
 variables:
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -13,7 +13,6 @@ resources:
     type: github
     endpoint: aspnet
     name: aspnet/AspnetWebHooks-Signed
-    ref: wtgodbe/SignTool
 
 variables:
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -13,6 +13,7 @@ resources:
     type: github
     endpoint: aspnet
     name: aspnet/AspnetWebHooks-Signed
+    ref: wtgodbe/SignTool2
 
 variables:
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -125,20 +125,21 @@ jobs:
               $(BuildScriptArgs)
               /bl:artifacts/logs/Build-Sign.binlog
       displayName: Build & Sign
-    - task: NuGetCommand@2
-      inputs:
-        command: 'push'
-        feedsToUse: 'select'
-        publishVstsFeed: 'public/general-testing'
-        packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/**/*.symbols.nupkg'
-      displayName: Publish packages to general-testing
-    - task: NuGetCommand@2
-      inputs:
-        command: 'push'
-        feedsToUse: 'select'
-        publishVstsFeed: 'public/general-testing-symbols'
-        packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/**/*.symbols.nupkg'
-      displayName: Publish symbols to general-testing-symbols
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: NuGetCommand@2
+        inputs:
+          command: 'push'
+          feedsToUse: 'select'
+          publishVstsFeed: 'public/general-testing'
+          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/**/*.symbols.nupkg'
+        displayName: Publish packages to general-testing
+      - task: NuGetCommand@2
+        inputs:
+          command: 'push'
+          feedsToUse: 'select'
+          publishVstsFeed: 'public/general-testing-symbols'
+          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/**/*.symbols.nupkg'
+        displayName: Publish symbols to general-testing-symbols
     - task: PublishBuildArtifacts@1
       displayName: Upload packages
       condition: eq(variables['system.pullrequest.isfork'], false)

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -70,6 +70,7 @@ jobs:
             $(BuildScriptArgs)
             /bl:artifacts/logs/Build-Release.binlog
     displayName: Build (Release)
+  - task: CopyFiles@2
     displayName: Copy packages to artifacts/
     inputs:
       sourceFolder: $(Build.SourcesDirectory)/bin/

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -150,7 +150,6 @@ jobs:
         parallel: true
     - task: PublishBuildArtifacts@1
       displayName: Upload logs
-      condition: eq(variables['system.pullrequest.isfork'], false)
       continueOnError: true
       inputs:
         pathtoPublish: artifacts/logs/

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -70,10 +70,16 @@ jobs:
             /bl:artifacts/logs/Build-Release.binlog
     displayName: Build (Release)
   - task: CopyFiles@2
-    displayName: Copy output to artifacts/
+    displayName: Copy logs to artifacts/
     inputs:
       sourceFolder: $(Build.SourcesDirectory)/bin/
-      contents: '**'
+      contents: 'logs/**'
+      targetFolder: $(Build.SourcesDirectory)/artifacts/
+  - task: CopyFiles@2
+    displayName: Copy packages to artifacts/
+    inputs:
+      sourceFolder: $(Build.SourcesDirectory)/bin/
+      contents: 'Release/**/*.nupkg'
       targetFolder: $(Build.SourcesDirectory)/artifacts/
   - task: CmdLine@2
     inputs:
@@ -88,8 +94,6 @@ jobs:
       artifactName: artifacts-AspnetWebHooks
       artifactType: Container
       parallel: true
-      FileCopyOptions: /xd "$(Build.SourcesDirectory)/artifacts/CodeAnalysis" "$(Build.SourcesDirectory)/artifacts/Test"
-                       /xf *.dll *.xml *.pdb
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - job: Webhooks_Signed_Build

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -1,5 +1,7 @@
-# Don't run CI for this config yet. We're not ready to move official builds on to Azure Pipelines
-trigger: none
+trigger:
+  branches:
+    include:
+    - master
 
 # Run PR validation on all branches
 pr:
@@ -91,7 +93,7 @@ jobs:
   - job: Webhooks_Signed_Build
     displayName: Build AspnetWebHooks-Signed
     dependsOn: Webhooks_Build
-    timeoutInMinutes: 180
+    timeoutInMinutes: 60
     workspace:
       clean: all
     pool:

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -84,10 +84,12 @@ jobs:
     condition: eq(variables['system.pullrequest.isfork'], false)
     continueOnError: true
     inputs:
-      pathtoPublish: artifacts/
+      pathtoPublish: $(Build.SourcesDirectory)/artifacts/
       artifactName: artifacts-AspnetWebHooks
       artifactType: Container
-      parallel: true 
+      parallel: true
+      FileCopyOptions: /xd "$(Build.SourcesDirectory)/artifacts/CodeAnalysis" "$(Build.SourcesDirectory)/artifacts/Test"
+                       /xf *.dll *.xml *.pdb
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - job: Webhooks_Signed_Build

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -125,7 +125,7 @@ jobs:
               $(BuildScriptArgs)
               /bl:artifacts/logs/Build-Sign.binlog
       displayName: Build & Sign
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
       - task: NuGetCommand@2
         inputs:
           command: 'push'

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -1,0 +1,131 @@
+# Don't run CI for this config yet. We're not ready to move official builds on to Azure Pipelines
+trigger: none
+
+# Run PR validation on all branches
+pr:
+  branches:
+    include:
+    - '*'
+
+resources:
+  repositories:
+  - repository: AspnetWebHooks-Signed
+    type: github
+    endpoint: aspnet
+    name: aspnet/AspnetWebHooks-Signed
+
+variables:
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - name: BuildScriptArgs
+    value: ''
+- ${{ if ne(variables['System.TeamProject'], 'public') }}:
+  - name: BuildScriptArgs
+    value: '/p:BuildNumber=$(Build.BuildId)'
+
+jobs:
+- job: Webhooks_Build
+  displayName: Build AspnetWebHooks
+  timeoutInMinutes: 60
+  workspace:
+    clean: all
+  pool:
+    name: NetCoreInternal-Pool
+    queue: BuildPool.Server.Amd64.VS2017
+  steps:
+  - checkout: self
+    clean: true
+  - task: NuGetToolInstaller@1
+    displayName: 'Install NuGet.exe'
+  - task: NuGetCommand@2
+    displayName: 'Clear NuGet caches'
+    inputs:
+      command: custom
+      arguments: 'locals all -clear'
+  - task: NuGetCommand@2
+    displayName: 'Restore Solution'
+    inputs:
+      restoreSolution: $(Build.SourcesDirectory)\AspNetWebHooks.sln
+      feedsToUse: config
+      nugetConfigPath: $(Build.SourcesDirectory)\.nuget\NuGet.config
+  - script: .\build.cmd
+            EnableSkipStrongNames
+            $(BuildScriptArgs)
+            /bl:artifacts/logs/Build-SkipStrongNames.binlog
+    displayName: Build (Skip StrongNames)
+  - script: .\build.cmd
+            BuildPackages
+            /p:Configuration=CodeAnalysis
+            $(BuildScriptArgs)
+            /bl:artifacts/logs/Build-CodeAnalysis.binlog
+    displayName: Build (CodeAnalysis)
+  - script: .\build.cmd
+            BuildPackages
+            /p:Configuration=Release
+            $(BuildScriptArgs)
+            /bl:artifacts/logs/Build-Release.binlog
+    displayName: Build (Release)
+  - task: CopyFiles@2
+    displayName: Copy output to artifacts/
+    inputs:
+      sourceFolder: $(Build.SourcesDirectory)/bin/
+      contents: '**'
+      targetFolder: $(Build.SourcesDirectory)/artifacts/
+  - task: CmdLine@2
+    inputs:
+      script: 'git rev-parse HEAD > artifacts/commit'
+    displayName: Create commit file
+  - task: PublishBuildArtifacts@1
+    displayName: Upload artifacts
+    condition: eq(variables['system.pullrequest.isfork'], false)
+    continueOnError: true
+    inputs:
+      pathtoPublish: artifacts/
+      artifactName: artifacts-AspnetWebHooks
+      artifactType: Container
+      parallel: true 
+
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - job: Webhooks_Signed_Build
+    displayName: Build AspnetWebHooks-Signed
+    dependsOn: Webhooks_Build
+    timeoutInMinutes: 180
+    workspace:
+      clean: all
+    pool:
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Server.Amd64.VS2019
+    variables:
+      TeamName: AspNetCore
+      _SignType: real
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1 # Skip signing telemetry to work around an error 
+    steps:
+    - checkout: AspnetWebHooks-Signed
+      clean: true
+    - task: MicroBuildSigningPlugin@2
+      displayName: Install MicroBuild Signing plugin
+      inputs:
+        signType: $(_SignType)
+        zipSources: false
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+    - task: DownloadBuildArtifacts@0
+      displayName: Download artifacts
+      inputs:
+        artifactName: artifacts-AspnetWebHooks
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - script: .\build.cmd
+              /t:BuildProjects
+              /p:Sign=Sign
+              /p:SignType=$(_SignType)
+              /p:DropSource=$(Build.StagingDirectory)/downloaded_artifacts/artifacts-AspnetWebHooks/
+              $(BuildScriptArgs)
+              /bl:artifacts/logs/Build-Sign.binlog
+      displayName: Build & Sign
+    - task: PublishBuildArtifacts@1
+      displayName: Upload artifacts
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: artifacts/
+        artifactName: artifacts-AspnetWebHooks-Signed
+        artifactType: Container
+        parallel: true 

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -13,6 +13,7 @@ resources:
     type: github
     endpoint: aspnet
     name: aspnet/AspnetWebHooks-Signed
+    ref: wtgodbe/SignTool
 
 variables:
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -123,6 +124,20 @@ jobs:
               $(BuildScriptArgs)
               /bl:artifacts/logs/Build-Sign.binlog
       displayName: Build & Sign
+    - task: NuGetCommand@2
+      inputs:
+        command: 'push'
+        feedsToUse: 'select'
+        vstsFeed: 'public/general-testing'
+        packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/**/*.symbols.nupkg'
+      displayName: Publish packages to general-testing
+    - task: NuGetCommand@2
+      inputs:
+        command: 'push'
+        feedsToUse: 'select'
+        vstsFeed: 'public/general-testing-symbols'
+        packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/**/*.symbols.nupkg'
+      displayName: Publish symbols to general-testing-symbols
     - task: PublishBuildArtifacts@1
       displayName: Upload artifacts
       condition: eq(variables['system.pullrequest.isfork'], false)
@@ -131,4 +146,4 @@ jobs:
         pathtoPublish: artifacts/
         artifactName: artifacts-AspnetWebHooks-Signed
         artifactType: Container
-        parallel: true 
+        parallel: true

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -30,8 +30,11 @@ jobs:
   workspace:
     clean: all
   pool:
-    name: NetCoreInternal-Pool
-    queue: BuildPool.Server.Amd64.VS2017
+    vmImage: vs2017-win2016
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      # This override makes the specified vmImage irrelevant.
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Server.Amd64.VS2017
   steps:
   - checkout: self
     clean: true

--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -152,6 +152,7 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: Upload logs
       continueOnError: true
+      continueOnError: true
       inputs:
         pathtoPublish: artifacts/logs/
         artifactName: artifacts-AspnetWebHooks-Signed-logs

--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -5,7 +5,7 @@
   </solution>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />
     <add key="externalComponentDependencies" value="https://www.myget.org/F/02a8fd0d231848d2ae32cd901e273000" />
   </packageSources>

--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -4,6 +4,7 @@
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <packageSources>
+  	<clear />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
     <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />
     <add key="externalComponentDependencies" value="https://www.myget.org/F/02a8fd0d231848d2ae32cd901e273000" />

--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -6,6 +6,6 @@
   <packageSources>
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-	<add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -6,7 +6,6 @@
   <packageSources>
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />
-    <add key="externalComponentDependencies" value="https://www.myget.org/F/02a8fd0d231848d2ae32cd901e273000" />
+	<add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Associated PR: https://github.com/aspnet/AspNetWebHooks-Signed/pull/6

Green internal build that produces signed packages: https://dev.azure.com/dnceng/internal/_build/results?buildId=978117&view=logs&j=01d1fc09-d21b-55cd-15c9-37c482634569&t=01d1fc09-d21b-55cd-15c9-37c482634569

There's still the question of where/how we want to publish the packages - we could have the pipeline publish them to a feed like dotnet-public, or just manually grab them from the build artifacts and push them on-demand like we do for jquery-validation-unobtrusive. Thoughts?