### PR TITLE
Use -Svc pools from here on out

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -45,11 +45,11 @@ jobs:
     clean: all
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: NetCore-Public
-      demands: ImageOverride -equals build.windows.10.amd64.vs2017.open
+      name: NetCore-Svc-Public
+      demands: ImageOverride -equals windows.vs2017.amd64.open
     ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals build.windows.10.amd64.vs2017
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals windows.vs2017.amd64
   variables:
   - ${{ if eq(variables.runCodeQL3000, 'true') }}:
     - name: _AdditionalBuildArgs
@@ -146,8 +146,8 @@ jobs:
     workspace:
       clean: all
     pool:
-      name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals build.windows.10.amd64.vs2017
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals windows.vs2017.amd64
     variables:
       TeamName: AspNetCore
       _SignType: real


### PR DESCRIPTION
- we _only_ service this repo
- also, use current image override names