### PR TITLE
Move to VS2019 image for signing

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -147,7 +147,7 @@ jobs:
       clean: all
     pool:
       name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals windows.vs2017.amd64
+      demands: ImageOverride -equals windows.vs2019.amd64
     variables:
       TeamName: AspNetCore
       _SignType: real


### PR DESCRIPTION
- need an image w/ .NET 3.1 on them; missing from VS2017 images