### PR TITLE
Opt out of internal dependabot PRs

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,3 @@
+version: 2
+enable-campaigned-updates: false
+enable-security-updates: false


### PR DESCRIPTION
We only want to get dependabot PRs in github, not AzDO